### PR TITLE
patch: use home-manager to install packages

### DIFF
--- a/modules/development/ansible/default.nix
+++ b/modules/development/ansible/default.nix
@@ -11,12 +11,13 @@
   };
 
   config = lib.mkIf config.dc-tec.development.ansible.enable {
-    environment.systemPackages = with pkgs; [
-      ansible
-      ansible-later
-      ansible-navigator
-      ansible-builder
-      ansible-lint
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        ansible
+        ansible-later
+        ansible-builder
+        ansible-lint
+      ];
+    };
   };
 }

--- a/modules/development/aws-cli/default.nix
+++ b/modules/development/aws-cli/default.nix
@@ -11,8 +11,10 @@
   };
 
   config = lib.mkIf config.dc-tec.development.aws-cli.enable {
-    environment.systemPackages = with pkgs; [
-      awscli2
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        awscli2
+      ];
+    };
   };
 }

--- a/modules/development/azure-cli/default.nix
+++ b/modules/development/azure-cli/default.nix
@@ -18,9 +18,11 @@
       (lib.mkIf (!config.dc-tec.core.persistence.enable) {})
     ];
 
-    environment.systemPackages = with pkgs; [
-      azure-cli
-      bicep
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        azure-cli
+        bicep
+      ];
+    };
   };
 }

--- a/modules/development/go/default.nix
+++ b/modules/development/go/default.nix
@@ -11,8 +11,10 @@
   };
 
   config = lib.mkIf config.dc-tec.development.go.enable {
-    environment.systemPackages = with pkgs; [
-      go
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        go
+      ];
+    };
   };
 }

--- a/modules/development/packer/default.nix
+++ b/modules/development/packer/default.nix
@@ -6,13 +6,15 @@
 }: {
   options = {
     dc-tec.development = {
-      packer.enable = lib.mkEnableOption "Terraform";
+      packer.enable = lib.mkEnableOption "Packer";
     };
   };
 
   config = lib.mkIf config.dc-tec.development.packer.enable {
-    environment.systemPackages = with pkgs; [
-      packer
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        packer
+      ];
+    };
   };
 }

--- a/modules/development/powershell/default.nix
+++ b/modules/development/powershell/default.nix
@@ -11,8 +11,10 @@
   };
 
   config = lib.mkIf config.dc-tec.development.powershell.enable {
-    environment.systemPackages = with pkgs; [
-      powershell
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        powershell
+      ];
+    };
   };
 }

--- a/modules/development/python/python312/default.nix
+++ b/modules/development/python/python312/default.nix
@@ -11,8 +11,10 @@
   };
 
   config = lib.mkIf config.dc-tec.development.python312.enable {
-    environment.systemPackages = with pkgs; [
-      python312
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        python312
+      ];
+    };
   };
 }

--- a/modules/development/terraform/default.nix
+++ b/modules/development/terraform/default.nix
@@ -13,9 +13,11 @@
   config = lib.mkIf config.dc-tec.development.terraform.enable {
     dc-tec.core.zfs.homeCacheLinks = lib.mkIf config.dc-tec.core.persistence.enable [".tenv"];
 
-    environment.systemPackages = with pkgs; [
-      tenv
-      terraform-docs
-    ];
+    home-manager.users.roelc = {
+      home.packages = with pkgs; [
+        tenv
+        terraform-docs
+      ];
+    };
   };
 }


### PR DESCRIPTION
Use home-manager instead of system packages to install the different development tools.