### PR TITLE
feat: Enable Git SignOff setting in lazygit

### DIFF
--- a/modules/darwin/development/git.nix
+++ b/modules/darwin/development/git.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   home-manager.users.roelc = {
     programs.git = {
       enable = true;
@@ -24,7 +25,11 @@
     programs.lazygit = {
       enable = true;
       catppuccin.enable = true;
+      settings = {
+        git = {
+          signOff = true;
+        };
+      };
     };
   };
 }
-


### PR DESCRIPTION
This pull request includes changes to the `modules/darwin/development/git.nix` file to enhance the configuration for Git and LazyGit. The most important changes include the addition of Git settings and a minor formatting adjustment.

Enhancements to Git and LazyGit configuration:

* Added a `settings` block to enable `signOff` for Git within the LazyGit configuration.