### PR TITLE
fix(cmux): disable active pane outline

### DIFF
--- a/modules/darwin/desktop/cmux.nix
+++ b/modules/darwin/desktop/cmux.nix
@@ -42,7 +42,9 @@ in
         "$schema" = "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json";
         schemaVersion = 1;
 
-        activePaneBorderColor = color "base0D";
+        # cmux draws the active outline inside the terminal surface, where it
+        # overlaps edge cells. Keep pane dividers, but disable that outline.
+        activePaneBorderColor = null;
         paneBorderColor = color "base02";
 
         app = {


### PR DESCRIPTION
## Summary

- disable cmux's focused-pane outline
- retain the subtle Catppuccin split-divider color
- document why the outline is intentionally disabled

## Why

cmux draws the active outline inside the terminal surface. It overlaps the edge cells of Neovim and terminal panes, obscuring text at the pane boundary.

## Impact

Focused panes no longer receive the blue inset outline. Split boundaries remain visible through the existing divider color.

## Validation

- visually verified in cmux
- `nix build --no-link .#checks.aarch64-darwin.pre-commit-check`
- `nix build --no-link .#darwinConfigurations.darwin.system`
- generated cmux JSON contains `activePaneBorderColor: null`
- `cmux config validate`
