### PR TITLE
chore(deps): update nixvim input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1785190933,
-        "narHash": "sha256-a+tN2xe23v/CrYXrFkPMPdw6Alhr5wPhgzmF2Lj87V0=",
+        "lastModified": 1785231009,
+        "narHash": "sha256-btLZRitK7g0Ong5+7zahHgPe7m111OP/Esl8S6p+peU=",
         "owner": "dc-tec",
         "repo": "nixvim",
-        "rev": "d7ecc009d40ad32144af46f64276f15cb4eec9e0",
+        "rev": "36684324139656aeeb66bd1896e194a50a2fd18b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- update the `nixvim` flake input from `d7ecc00` to `3668432`
- exercise the newly populated `dc-tec-nixos-config` Cachix cache

## Validation

- `nix develop --command pre-commit run --all-files`
- `nix build .#checks.aarch64-darwin.darwin-system --no-link --print-build-logs`
- all required GitHub Actions checks

Cross-evaluating the Linux hosts from Apple Silicon still reaches the existing Catppuccin `x86_64-linux` platform mismatch; the native Linux CI jobs provide that validation.

## Cache benchmark

Baseline population run: https://github.com/dc-tec/nixos-config/actions/runs/30357536075
Cached PR run: https://github.com/dc-tec/nixos-config/actions/runs/30367385558

| Job | Baseline | Cached | Reduction |
| --- | ---: | ---: | ---: |
| Quality | 1m 07s | 1m 00s | 10% |
| Ghost | 13m 52s | 2m 26s | 82% |
| Legion | 14m 23s | 3m 01s | 79% |
| Chad | 15m 59s | 3m 17s | 79% |
| Darwin | 26m 49s | 7m 42s | 71% |