### PR TITLE
fix(forge): align mdraid kernel compatibility

### DIFF
--- a/docs/machine-forge.md
+++ b/docs/machine-forge.md
@@ -8,17 +8,21 @@ becoming a general-purpose homelab or a customer-data platform.
 
 The host has a buildable server baseline and a Disko storage definition based
 on inventory collected from the temporary Debian installation. The Disko
-definition is destructive and has not been applied yet.
+definition has been applied to the host and remains destructive when rerun.
 
 Do not run Disko or `nixos-anywhere` before reviewing the disk identities and
-storage plan below. Applying it erases all three SSDs, including the temporary
-Debian installation.
+storage plan below. Applying it erases all three SSDs.
 
 ## Configuration Boundary
 
 The server uses the stable NixOS 26.05 package set and a dedicated minimal
 module stack. It does not inherit workstation Home Manager configuration,
 desktop theming, impermanence, personal SOPS material, or automatic upgrades.
+The host selects `linuxPackages_latest` because current `nixos-anywhere` kexec
+images create mdraid metadata that requires Linux 6.19 or newer. An assertion
+prevents accidentally selecting an incompatible older kernel. Do not lower
+that boundary without also using a compatible custom kexec image and
+recreating the arrays.
 
 The initial baseline provides:
 

--- a/machines/forge/hardware.nix
+++ b/machines/forge/hardware.nix
@@ -1,8 +1,27 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 
+  assertions = [
+    {
+      assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.19";
+      message = ''
+        forge requires Linux 6.19 or newer because the nixos-anywhere installer
+        records the mdraid logical block size introduced by Linux 6.19.
+      '';
+    }
+  ];
+
   boot = {
+    # Keep the installed kernel compatible with mdraid arrays created by the
+    # current nixos-anywhere kexec image.
+    kernelPackages = pkgs.linuxPackages_latest;
+
     initrd = {
       availableKernelModules = [
         "ahci"


### PR DESCRIPTION
## Summary

- select `linuxPackages_latest` for the dedicated `forge` host
- assert that the selected kernel is Linux 6.19 or newer
- document the mdraid compatibility boundary and the destructive reinstall behavior

## Root cause

The default `nixos-anywhere` kexec image currently boots Linux 7.0.9. Linux
6.19 and newer record the array logical block size in mdraid v1 superblocks.
The installed `forge` configuration selected Linux 6.18.40, which rejects
those newly created arrays with `EINVAL` and times out waiting for
`/dev/md/forge-root` during initrd.

This matches the upstream compatibility boundary documented in
[Debian bug #1130775](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1130775).

## Impact

The pinned lock currently resolves the forge kernel to Linux 7.1.5, so it can
assemble arrays created by the current installer. The guard prevents a later
configuration change from silently selecting an incompatible pre-6.19
kernel.

This PR only changes and validates the declarative configuration. Reinstalling
the fresh server remains a separate, explicit destructive operation after CI
and review.

## Validation

- `nix build .#checks.aarch64-darwin.pre-commit-check --print-build-logs`
- `nix eval --raw .#nixosConfigurations.forge.config.boot.kernelPackages.kernel.version` -> `7.1.5`
- evaluated the forge system and Disko derivation paths
- verified both RAID1 member sets are clean and complete from the rescue environment
- verified the on-disk superblock contains `logical_block_size = 512`
- verified the default kexec image uses Linux 7.0.9

The native x86-64 host and Disko builds remain delegated to Linux CI.
