### PR TITLE
feat(forge): add selective Radicle node

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ workstation modules. This separation is explicit in `flake.nix`.
 - SOPS with age-backed secret decryption for workstation configuration;
 - WireGuard-only administration, Restic backups, Prometheus, Alertmanager and
   Grafana on Forge;
-- a signed, read-only native Nix binary cache for managed systems; and
+- a signed, read-only native Nix binary cache for managed systems;
+- a selectively replicating public Radicle node with a dedicated host
+  identity; and
 - repository-local packages for repeatable Forge provisioning and cache
   publication.
 

--- a/docs/machine-forge.md
+++ b/docs/machine-forge.md
@@ -80,7 +80,8 @@ through rclone's FTP backend. The initial backup set contains state that cannot
 be reconstructed from this repository:
 
 - the WireGuard private key;
-- the Nix cache signing key; and
+- the Nix cache signing key;
+- the Radicle node identity key; and
 - the SSH host keys.
 
 Nix store paths, cache contents, logs, metrics and public repositories are not
@@ -227,6 +228,88 @@ nix store verify --no-contents --recursive "$hello"
 GitHub Actions continues to use Cachix. External runners do not receive Forge
 publication authority. Cache eviction remains an explicit operator action.
 
+## Radicle Node
+
+Forge runs a selective Radicle seed node on public TCP port `8776`. The node
+advertises `radicle.decort.tech:8776`; the DNS record remains DNS-only because
+the Radicle protocol does not traverse the Cloudflare HTTP proxy. The HTTP
+gateway and web explorer are not enabled.
+
+The node uses a dedicated identity rather than the workstation maintainer
+identity:
+
+```text
+Node ID: z6Mkv2Vt5s46dasz4m2Ht7rA8nnxDnwXp4Q6enhwt2V1RKMZ
+Address: z6Mkv2Vt5s46dasz4m2Ht7rA8nnxDnwXp4Q6enhwt2V1RKMZ@radicle.decort.tech:8776
+```
+
+The public key is committed in `public-keys.nix`. SecretSpec keeps the
+unencrypted private key in the operator's Apple Keychain and provisions it to:
+
+```text
+/var/lib/forge-secrets/radicle-node
+```
+
+An unencrypted key is used because the node must restart unattended. The file
+is root-owned with mode `0400` and is passed to the confined service as a
+systemd credential. Provision it over WireGuard with:
+
+```console
+secretspec check --profile default --scope forge-radicle \
+  --reason "Provision the Forge Radicle node identity"
+secretspec run --profile default --scope forge-radicle \
+  --reason "Provision the Forge Radicle node identity" -- \
+  provision-forge-radicle-key
+```
+
+The service is skipped when the key is absent instead of entering a restart
+loop. After provisioning a newly deployed host, start the node and apply the
+declared repository policy:
+
+```console
+ssh roelc@10.77.0.1 sudo systemctl start \
+  radicle-node.service \
+  forge-radicle-seed.service \
+  forge-radicle-metrics.service
+```
+
+The default seeding policy is `block`. `forge-radicle-seed.service` grants a
+`followed` policy only to the public repository identifiers declared in the
+Radicle module. It currently seeds `nixos-config`; removing a repository from
+that list does not delete its existing replica automatically.
+
+The service has an explicit memory and task budget so public replication cannot
+consume the engineering server without bound. Monitoring verifies the node's
+administrative interface, each declared repository identity, and its expected
+`followed` policy in addition to process and listener availability.
+
+Inspect the node and its policies with:
+
+```console
+ssh roelc@10.77.0.1 sudo rad-system node status
+ssh roelc@10.77.0.1 sudo rad-system node config --addresses
+ssh roelc@10.77.0.1 sudo rad-system seed
+ssh roelc@10.77.0.1 sudo journalctl -u radicle-node.service
+```
+
+From another Radicle node, verify the public path with:
+
+```console
+rad node connect \
+  z6Mkv2Vt5s46dasz4m2Ht7rA8nnxDnwXp4Q6enhwt2V1RKMZ@radicle.decort.tech:8776
+rad sync status
+```
+
+The encrypted Forge backup includes the node identity key. Replicated public
+repository data under `/var/lib/radicle` is reconstructible and deliberately
+excluded. The configured repository list restores the seeding policy after a
+new node starts. A restore must reproduce the same Node ID before the recovered
+node is advertised.
+
+To roll back the service, stop the node and remove the module from the Forge
+composition. Preserve the identity key until the old Node ID and address have
+been retired deliberately.
+
 ## Build and Deployment
 
 Evaluate the Forge system and Disko derivations from any supported client:
@@ -266,10 +349,9 @@ nix run .#nixos-anywhere -- \
 
 Stateful applications are added as independent, reversible slices:
 
-1. a Radicle node;
-2. a Tangled knot;
-3. OpenBao with identity integration; and
-4. an optional private Attic evaluation, separate from the native cache.
+1. a Tangled knot;
+2. OpenBao with identity integration; and
+3. an optional private Attic evaluation, separate from the native cache.
 
 Each service must define its network exposure, state ownership, backup and
 restore procedure, monitoring, acceptance checks and rollback path.

--- a/modules/nixos/server/forge/backup.nix
+++ b/modules/nixos/server/forge/backup.nix
@@ -33,6 +33,9 @@ in
         if [ -f /var/lib/forge-secrets/nix-cache-private-key ]; then
           printf '%s\n' /var/lib/forge-secrets/nix-cache-private-key
         fi
+        if [ -f /var/lib/forge-secrets/radicle-node ]; then
+          printf '%s\n' /var/lib/forge-secrets/radicle-node
+        fi
         ${lib.getExe' pkgs.findutils "find"} /etc/ssh \
           -maxdepth 1 \
           -type f \

--- a/modules/nixos/server/forge/default.nix
+++ b/modules/nixos/server/forge/default.nix
@@ -4,5 +4,6 @@ _: {
     ./backup.nix
     ./cache.nix
     ./monitoring.nix
+    ./radicle.nix
   ];
 }

--- a/modules/nixos/server/forge/grafana-dashboards/forge-overview.json
+++ b/modules/nixos/server/forge/grafana-dashboards/forge-overview.json
@@ -835,6 +835,84 @@
       ],
       "title": "Backup objects",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Unavailable"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Healthy"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "min({__name__=~\"forge_radicle_(identity_present|node_active|tcp_listening|control_ready|repository_present|seed_policy_applied)\"})",
+          "instant": true,
+          "legendFormat": "Health",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Radicle health",
+      "type": "stat"
     }
   ],
   "refresh": "30s",
@@ -853,5 +931,5 @@
   "timezone": "browser",
   "title": "Forge Overview",
   "uid": "forge-overview",
-  "version": 1
+  "version": 2
 }

--- a/modules/nixos/server/forge/prometheus-rules.test.yml
+++ b/modules/nixos/server/forge/prometheus-rules.test.yml
@@ -284,6 +284,78 @@ tests:
               description: "No successful cache metrics scan has been recorded within the last 15 minutes."
 
   - interval: 1m
+    input_series:
+      - series: 'forge_radicle_identity_present{instance="forge",job="node"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeRadicleIdentityMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              category: radicle
+              instance: forge
+              job: node
+            exp_annotations:
+              summary: "Forge Radicle node identity is missing"
+              description: "The dedicated Radicle node private key has not been provisioned on Forge."
+
+  - interval: 1m
+    input_series:
+      - series: 'forge_radicle_identity_present{instance="forge",job="node"}'
+        values: "1x15"
+      - series: 'forge_radicle_node_active{instance="forge",job="node"}'
+        values: "0x15"
+      - series: 'forge_radicle_tcp_listening{instance="forge",job="node"}'
+        values: "0x15"
+      - series: 'forge_radicle_control_ready{instance="forge",job="node"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeRadicleNodeUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              category: radicle
+              instance: forge
+              job: node
+            exp_annotations:
+              summary: "Forge Radicle node is unavailable"
+              description: "The Radicle identity is present, but the node service, protocol listener, or administrative interface is unavailable."
+
+  - interval: 1m
+    input_series:
+      - series: 'forge_radicle_repository_present{instance="forge",job="node",rid="rad:z4FGmdE1XLWBUPTNBe4cJUQvJ5WyX"}'
+        values: "1x15"
+      - series: 'forge_radicle_seed_policy_applied{instance="forge",job="node",rid="rad:z4FGmdE1XLWBUPTNBe4cJUQvJ5WyX"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeRadicleRepositoryUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              category: radicle
+              instance: forge
+              job: node
+              rid: rad:z4FGmdE1XLWBUPTNBe4cJUQvJ5WyX
+            exp_annotations:
+              summary: "Forge is not replicating declared Radicle repository rad:z4FGmdE1XLWBUPTNBe4cJUQvJ5WyX"
+              description: "The repository is absent, has an invalid identity, or no longer uses the declared followed seeding policy."
+
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeRadicleMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              category: radicle
+            exp_annotations:
+              summary: "Forge Radicle metrics are stale"
+              description: "No successful Radicle metrics scan has been recorded within the last 15 minutes."
+
+  - interval: 1m
     alert_rule_test:
       - eval_time: 30m
         alertname: ForgeBackupMaintenanceStale

--- a/modules/nixos/server/forge/prometheus-rules.yml
+++ b/modules/nixos/server/forge/prometheus-rules.yml
@@ -13,7 +13,7 @@ groups:
 
       - alert: ForgeServiceFailed
         expr: >-
-          node_systemd_unit_state{instance="forge",state="failed",name=~"(grafana|prometheus|prometheus-node-exporter|prometheus-smartctl-exporter|alertmanager|nginx|restic-backups-forge-state|restic-backups-forge-maintenance|forge-backup-.*-metrics|forge-cache-.*)\\.service"} == 1
+          node_systemd_unit_state{instance="forge",state="failed",name=~"(grafana|prometheus|prometheus-node-exporter|prometheus-smartctl-exporter|alertmanager|nginx|radicle-node|restic-backups-forge-state|restic-backups-forge-maintenance|forge-backup-.*-metrics|forge-cache-.*|forge-radicle-.*)\\.service"} == 1
         for: 5m
         labels:
           severity: critical
@@ -145,6 +145,59 @@ groups:
         annotations:
           summary: "Forge Nix cache metrics are stale"
           description: "No successful cache metrics scan has been recorded within the last 15 minutes."
+
+  - name: forge-radicle
+    rules:
+      - alert: ForgeRadicleIdentityMissing
+        expr: forge_radicle_identity_present == 0
+        for: 10m
+        labels:
+          severity: critical
+          category: radicle
+        annotations:
+          summary: "Forge Radicle node identity is missing"
+          description: "The dedicated Radicle node private key has not been provisioned on Forge."
+
+      - alert: ForgeRadicleNodeUnavailable
+        expr: >-
+          (forge_radicle_identity_present == 1)
+          and
+          ((forge_radicle_node_active == 0)
+          or (forge_radicle_tcp_listening == 0)
+          or (forge_radicle_control_ready == 0))
+        for: 10m
+        labels:
+          severity: warning
+          category: radicle
+        annotations:
+          summary: "Forge Radicle node is unavailable"
+          description: "The Radicle identity is present, but the node service, protocol listener, or administrative interface is unavailable."
+
+      - alert: ForgeRadicleRepositoryUnavailable
+        expr: >-
+          (forge_radicle_repository_present == 0)
+          or
+          (forge_radicle_seed_policy_applied == 0)
+        for: 10m
+        labels:
+          severity: critical
+          category: radicle
+        annotations:
+          summary: "Forge is not replicating declared Radicle repository {{ $labels.rid }}"
+          description: "The repository is absent, has an invalid identity, or no longer uses the declared followed seeding policy."
+
+      - alert: ForgeRadicleMetricsStale
+        expr: >-
+          (time() - forge_radicle_last_scan_timestamp_seconds > 900)
+          or
+          absent(forge_radicle_last_scan_timestamp_seconds)
+        for: 10m
+        labels:
+          severity: warning
+          category: radicle
+        annotations:
+          summary: "Forge Radicle metrics are stale"
+          description: "No successful Radicle metrics scan has been recorded within the last 15 minutes."
 
   - name: forge-backup
     rules:

--- a/modules/nixos/server/forge/radicle.nix
+++ b/modules/nixos/server/forge/radicle.nix
@@ -1,0 +1,225 @@
+{
+  lib,
+  pkgs,
+  publicKeys,
+  ...
+}:
+let
+  privateKeyFile = "/var/lib/forge-secrets/radicle-node";
+  metricDirectory = "/var/lib/prometheus-node-exporter-text-files";
+  nodePort = 8776;
+  radSystem = "/run/current-system/sw/bin/rad-system";
+
+  seedRepositories = [
+    "rad:z4FGmdE1XLWBUPTNBe4cJUQvJ5WyX" # nixos-config
+  ];
+
+  seedRepositoriesScript = pkgs.writeShellApplication {
+    name = "forge-radicle-seed";
+    text = ''
+      repositories=(${lib.escapeShellArgs seedRepositories})
+      for rid in "''${repositories[@]}"; do
+        /run/current-system/sw/bin/rad-system seed \
+          --scope followed \
+          --timeout 2min \
+          "$rid"
+      done
+    '';
+  };
+
+  radicleMetrics = pkgs.writeShellApplication {
+    name = "forge-radicle-metrics";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.iproute2
+      pkgs.systemd
+    ];
+    text = ''
+      target="${metricDirectory}/forge_radicle.prom"
+      temporary="$target.$$"
+      trap 'rm -f -- "$temporary"' EXIT
+
+      if [[ -s "${privateKeyFile}" ]]; then
+        identity_present=1
+      else
+        identity_present=0
+      fi
+
+      if systemctl is-active --quiet radicle-node.service; then
+        node_active=1
+      else
+        node_active=0
+      fi
+
+      if ss --no-header --listening --tcp --numeric \
+        "sport = :${toString nodePort}" | grep --quiet .; then
+        tcp_listening=1
+      else
+        tcp_listening=0
+      fi
+
+      if [[ "$node_active" == 1 ]] \
+        && timeout 10s ${radSystem} node status >/dev/null 2>&1; then
+        control_ready=1
+      else
+        control_ready=0
+      fi
+
+      repository_metrics=()
+      repositories=(${lib.escapeShellArgs seedRepositories})
+      for rid in "''${repositories[@]}"; do
+        if timeout 15s ${radSystem} inspect "$rid" --identity >/dev/null 2>&1; then
+          repository_present=1
+        else
+          repository_present=0
+        fi
+
+        policy_output="$(
+          timeout 15s ${radSystem} inspect "$rid" --policy 2>/dev/null || true
+        )"
+        # The backticks are literal characters in the rad-system output.
+        # shellcheck disable=SC2016
+        if grep --fixed-strings --quiet 'scope `followed`' <<< "$policy_output"; then
+          seed_policy_applied=1
+        else
+          seed_policy_applied=0
+        fi
+
+        repository_metrics+=(
+          "forge_radicle_repository_present{rid=\"$rid\"} $repository_present"
+          "forge_radicle_seed_policy_applied{rid=\"$rid\"} $seed_policy_applied"
+        )
+      done
+
+      printf '%s\n' \
+        '# HELP forge_radicle_identity_present Whether the Forge Radicle node private key is provisioned.' \
+        '# TYPE forge_radicle_identity_present gauge' \
+        "forge_radicle_identity_present $identity_present" \
+        '# HELP forge_radicle_node_active Whether the Forge Radicle node service is active.' \
+        '# TYPE forge_radicle_node_active gauge' \
+        "forge_radicle_node_active $node_active" \
+        '# HELP forge_radicle_tcp_listening Whether the Forge Radicle protocol port is listening.' \
+        '# TYPE forge_radicle_tcp_listening gauge' \
+        "forge_radicle_tcp_listening $tcp_listening" \
+        '# HELP forge_radicle_control_ready Whether the Forge Radicle administrative interface responds.' \
+        '# TYPE forge_radicle_control_ready gauge' \
+        "forge_radicle_control_ready $control_ready" \
+        '# HELP forge_radicle_repository_present Whether a declared Radicle repository is present and has a valid identity.' \
+        '# TYPE forge_radicle_repository_present gauge' \
+        '# HELP forge_radicle_seed_policy_applied Whether a declared Radicle repository has the followed seeding policy.' \
+        '# TYPE forge_radicle_seed_policy_applied gauge' \
+        "''${repository_metrics[@]}" \
+        '# HELP forge_radicle_last_scan_timestamp_seconds Unix timestamp of the last Radicle metrics scan.' \
+        '# TYPE forge_radicle_last_scan_timestamp_seconds gauge' \
+        "forge_radicle_last_scan_timestamp_seconds $(date +%s)" \
+        > "$temporary"
+
+      chmod 0644 "$temporary"
+      mv --force -- "$temporary" "$target"
+    '';
+  };
+in
+{
+  assertions = [
+    {
+      assertion = lib.hasPrefix "ssh-ed25519 " publicKeys.radicle.forge;
+      message = "The Forge Radicle node public key must be an Ed25519 SSH public key.";
+    }
+    {
+      assertion = builtins.length (lib.splitString " " publicKeys.radicle.forge) == 2;
+      message = "The Forge Radicle node public key must not contain an SSH comment.";
+    }
+  ];
+
+  services.radicle = {
+    enable = true;
+    package = pkgs.radicle-node;
+    privateKey = privateKeyFile;
+    publicKey = publicKeys.radicle.forge;
+
+    node = {
+      listenAddress = "0.0.0.0";
+      listenPort = nodePort;
+      openFirewall = true;
+    };
+
+    settings.node = {
+      alias = "radicle.decort.tech";
+      externalAddresses = [ "radicle.decort.tech:${toString nodePort}" ];
+      seedingPolicy.default = "block";
+    };
+  };
+
+  systemd = {
+    services = {
+      radicle-node = {
+        unitConfig.ConditionPathExists = privateKeyFile;
+        serviceConfig = {
+          MemoryHigh = "1G";
+          MemoryMax = "2G";
+          TasksMax = 256;
+        };
+      };
+
+      forge-radicle-seed = {
+        description = "Apply the Forge Radicle repository seeding policy";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "radicle-node.service" ];
+        after = [ "radicle-node.service" ];
+        unitConfig.ConditionPathExists = privateKeyFile;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = lib.getExe seedRepositoriesScript;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
+        };
+      };
+
+      forge-radicle-metrics = {
+        description = "Collect Forge Radicle node metrics";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = lib.getExe radicleMetrics;
+          User = "root";
+          Group = "root";
+          UMask = "0022";
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "strict";
+          ReadOnlyPaths = [ "-${privateKeyFile}" ];
+          ReadWritePaths = [ metricDirectory ];
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
+        };
+      };
+    };
+
+    timers.forge-radicle-metrics = {
+      description = "Schedule Forge Radicle node metrics collection";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2m";
+        OnUnitActiveSec = "5m";
+        Unit = "forge-radicle-metrics.service";
+      };
+    };
+
+    tmpfiles.rules = [
+      "d /var/lib/radicle 0750 radicle radicle -"
+      "f /var/lib/radicle/.gitconfig 0644 radicle radicle -"
+    ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,6 +12,7 @@ in
   nh-darwin-switch-publish = forgeTools.nhDarwinSwitchPublish;
   provision-forge-backup-secret = forgeTools.provisionForgeBackupSecret;
   provision-forge-cache-key = forgeTools.provisionForgeCacheKey;
+  provision-forge-radicle-key = forgeTools.provisionForgeRadicleKey;
   publish-forge-cache = forgeTools.publishForgeCache;
   niks-cli = pkgs.callPackage ./niks { inherit inputs; };
 }

--- a/pkgs/forge-tools/default.nix
+++ b/pkgs/forge-tools/default.nix
@@ -60,6 +60,17 @@ let
     description = "Verify and provision the Forge binary-cache signing key";
   };
 
+  provisionForgeRadicleKey = mkTool {
+    name = "provision-forge-radicle-key";
+    source = ./provision-forge-radicle-key.bash;
+    runtimeInputs = [
+      coreutils
+      openssh
+    ];
+    runtimeEnv.FORGE_RADICLE_PUBLIC_KEY = publicKeys.radicle.forge;
+    description = "Verify and provision the Forge Radicle node identity";
+  };
+
   nhDarwinSwitchPublish = mkTool {
     name = "nh-darwin-switch-publish";
     source = ./nh-darwin-switch-publish.bash;
@@ -77,6 +88,7 @@ in
     nhDarwinSwitchPublish
     provisionForgeBackupSecret
     provisionForgeCacheKey
+    provisionForgeRadicleKey
     publishForgeCache
     ;
 
@@ -86,6 +98,7 @@ in
       nhDarwinSwitchPublish
       provisionForgeBackupSecret
       provisionForgeCacheKey
+      provisionForgeRadicleKey
       publishForgeCache
     ];
   };

--- a/pkgs/forge-tools/provision-forge-radicle-key.bash
+++ b/pkgs/forge-tools/provision-forge-radicle-key.bash
@@ -1,0 +1,78 @@
+: "${FORGE_RADICLE_PRIVATE_KEY:?Run this script through SecretSpec with the forge-radicle scope}"
+: "${FORGE_RADICLE_PUBLIC_KEY:?The packaged Radicle public key is missing}"
+
+target="${FORGE_SSH_TARGET:-roelc@10.77.0.1}"
+secret_file="/var/lib/forge-secrets/radicle-node"
+expected_public_key="$FORGE_RADICLE_PUBLIC_KEY"
+ssh_options=(
+  -F /dev/null
+  -o BatchMode=yes
+)
+temporary_directory="$(mktemp --directory)"
+temporary_key="$temporary_directory/radicle-node"
+
+cleanup() {
+  if [[ -f "$temporary_key" ]]; then
+    key_size="$(wc --bytes < "$temporary_key")"
+    dd if=/dev/zero of="$temporary_key" bs=1 count="$key_size" conv=notrunc status=none
+    rm --force -- "$temporary_key"
+  fi
+  rmdir "$temporary_directory"
+}
+trap cleanup EXIT
+
+umask 0077
+printf '%s\n' "$FORGE_RADICLE_PRIVATE_KEY" > "$temporary_key"
+actual_public_key="$(ssh-keygen -y -f "$temporary_key")"
+
+if [[ "$actual_public_key" != "$expected_public_key" ]]; then
+  echo "the SecretSpec key does not match public-keys.nix" >&2
+  exit 1
+fi
+
+ssh "${ssh_options[@]}" -T "$target" \
+  "set -eu
+    cleanup_candidate() {
+      sudo rm -f -- ${secret_file}.new
+    }
+    trap cleanup_candidate EXIT
+    sudo install -d -m 0700 -o root -g root /var/lib/forge-secrets
+    sudo install -m 0600 -o root -g root /dev/null ${secret_file}.new
+    sudo tee ${secret_file}.new >/dev/null
+    sudo chmod 0400 ${secret_file}.new
+    trap - EXIT" \
+  < "$temporary_key"
+
+if ! candidate_public_key="$(
+  ssh "${ssh_options[@]}" -T "$target" \
+    "sudo ssh-keygen -y -f ${secret_file}.new"
+)"; then
+  ssh "${ssh_options[@]}" -T "$target" \
+    "sudo rm -f -- ${secret_file}.new"
+  echo "the uploaded Radicle key is invalid; the active key was not changed" >&2
+  exit 1
+fi
+
+if [[ "$candidate_public_key" != "$expected_public_key" ]]; then
+  ssh "${ssh_options[@]}" -T "$target" \
+    "sudo rm -f -- ${secret_file}.new"
+  echo "the uploaded Radicle key does not match public-keys.nix; the active key was not changed" >&2
+  exit 1
+fi
+
+ssh "${ssh_options[@]}" -T "$target" \
+  "sudo mv -- ${secret_file}.new ${secret_file}"
+
+remote_public_key="$(
+  ssh "${ssh_options[@]}" -T "$target" \
+    "sudo ssh-keygen -y -f ${secret_file}"
+)"
+
+if [[ "$remote_public_key" != "$expected_public_key" ]]; then
+  echo "the active Radicle key does not match public-keys.nix after installation" >&2
+  exit 1
+fi
+
+ssh "${ssh_options[@]}" -T "$target" \
+  "sudo stat --format='provisioned %a %U:%G %n' ${secret_file}"
+printf 'verified public key %s\n' "$remote_public_key"

--- a/public-keys.nix
+++ b/public-keys.nix
@@ -1,4 +1,5 @@
 {
   ssh.roelc = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHQ7HSO8O+R1NoKTzdcqWrANt0przSD6ucWqY9G/tJN9 roelc@legion";
   nixCache.forge = "cache.decort.tech-1:VDiJjxhvNqm2qFKdtfS0KJX+7FnS9ArGOnr7ujuD1rw=";
+  radicle.forge = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOdjHXgvunOF3QnbTsBSBMy8DicdrFMkqKnyPSuOuvIw";
 }

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -8,9 +8,13 @@ keychain = "keyring://"
 [profiles.default]
 FORGE_RESTIC_PASSWORD = { description = "Encryption password for the forge Restic repository", providers = ["keychain"], type = "password", generate = true }
 FORGE_NIX_CACHE_PRIVATE_KEY = { description = "Ed25519 private signing key for cache.decort.tech", providers = ["keychain"], type = "password" }
+FORGE_RADICLE_PRIVATE_KEY = { description = "Ed25519 private key for the forge Radicle node", providers = ["keychain"], type = "password" }
 
 [scopes.forge-backup]
 secrets = ["FORGE_RESTIC_PASSWORD"]
 
 [scopes.forge-cache]
 secrets = ["FORGE_NIX_CACHE_PRIVATE_KEY"]
+
+[scopes.forge-radicle]
+secrets = ["FORGE_RADICLE_PRIVATE_KEY"]


### PR DESCRIPTION
## Summary

- add a hardened public Radicle seed with a dedicated, recoverable identity
- default to blocking repository seeding and explicitly allow only configured public repositories
- add health metrics, alerts, Grafana visibility, resource limits, backup coverage, provisioning tooling and operator documentation

## Operational and security boundaries

- expose only Radicle peer traffic on TCP 8776; no public HTTP gateway or explorer
- keep the private identity key outside the Nix store as a root-only systemd credential, provisioned through SecretSpec and covered by encrypted backups
- treat repository data as reconstructible while backing up the identity required for continuity
- retain GitHub as the integration authority; Tangled and Radicle will be reconciled to the exact accepted commit after merge

## Validation

- `nix build .#checks.aarch64-darwin.pre-commit-check --no-link --print-build-logs`
- `nix build .#forge-tools --no-link --print-build-logs`
- `nix build .#checks.aarch64-darwin.darwin-system --no-link --print-build-logs`
- `promtool test rules modules/nixos/server/forge/prometheus-rules.test.yml`
- built and activated the exact staged Forge system with `nixos-rebuild test`
- verified all seven Radicle health metrics report `1`, no Radicle alerts or failed units are present, the node identity survives SecretSpec reprovisioning, and the configured repository is available to the connected workstation peer
- `systemd-analyze security radicle-node` reports `1.0 OK`
