### PR TITLE
feat(forge): add Tangled knot and selective CI

### DIFF
--- a/.github/scripts/select-nix-builds.sh
+++ b/.github/scripts/select-nix-builds.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+all_hosts=(legion chad ghost forge)
+
+emit_selection() {
+  local darwin="$1"
+  shift
+  local hosts
+  hosts="$(jq --compact-output --null-input --args '$ARGS.positional' -- "$@")"
+  jq --compact-output --null-input \
+    --argjson hosts "$hosts" \
+    --argjson darwin "$darwin" \
+    '{ hosts: $hosts, darwin: $darwin }'
+}
+
+if [[ "${1:-}" == "--all" ]]; then
+  emit_selection true "${all_hosts[@]}"
+  exit 0
+fi
+
+if [[ $# -ne 3 ]]; then
+  printf 'usage: %s BASE_FLAKE HEAD_FLAKE CHANGED_FILES\n' "$0" >&2
+  exit 64
+fi
+
+base_flake="$1"
+head_flake="$2"
+changed_files="$3"
+nix_command="${NIX_COMMAND:-nix}"
+
+if [[ ! -r "$changed_files" ]]; then
+  printf 'changed-files list is not readable: %s\n' "$changed_files" >&2
+  exit 66
+fi
+
+linux_candidate=false
+darwin_candidate=false
+force_all=false
+
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+
+  case "$path" in
+    .github/workflows/nix.yml | .github/scripts/select-nix-builds.sh | .github/scripts/test-select-nix-builds.sh)
+      force_all=true
+      ;;
+    flake.nix | flake.lock | public-keys.nix | .sops.yaml | lib/* | overlays/* | pkgs/* | secrets/*)
+      linux_candidate=true
+      darwin_candidate=true
+      ;;
+    machines/darwin/* | modules/darwin/* | modules/shared/*)
+      darwin_candidate=true
+      if [[ "$path" == modules/shared/* ]]; then
+        linux_candidate=true
+      fi
+      ;;
+    machines/* | modules/nixos/*)
+      linux_candidate=true
+      ;;
+    *.nix)
+      # Unknown Nix sources are treated as cross-platform until their place in
+      # the module graph is made explicit above.
+      linux_candidate=true
+      darwin_candidate=true
+      ;;
+  esac
+done < "$changed_files"
+
+if [[ "$force_all" == true ]]; then
+  emit_selection true "${all_hosts[@]}"
+  exit 0
+fi
+
+if [[ "$linux_candidate" != true ]]; then
+  emit_selection "$darwin_candidate"
+  exit 0
+fi
+
+fingerprints() {
+  local flake="$1"
+  "$nix_command" eval --json "${flake}#checks.x86_64-linux" --apply '
+    checks: {
+      legion = [ checks.nixos-legion.drvPath ];
+      chad = [ checks.nixos-chad.drvPath ];
+      ghost = [ checks.nixos-ghost.drvPath ];
+      forge = [
+        checks.nixos-forge.drvPath
+        checks.forge-disko.drvPath
+        checks.forge-alert-rules.drvPath
+      ];
+    }
+  '
+}
+
+selected_hosts=()
+comparison_failed=false
+
+if ! base_fingerprints="$(fingerprints "$base_flake")"; then
+  comparison_failed=true
+elif ! head_fingerprints="$(fingerprints "$head_flake")"; then
+  comparison_failed=true
+else
+  for host in "${all_hosts[@]}"; do
+    base_host="$(jq --compact-output --arg host "$host" '.[$host]' \
+      <<< "$base_fingerprints")"
+    head_host="$(jq --compact-output --arg host "$host" '.[$host]' \
+      <<< "$head_fingerprints")"
+    if [[ "$base_host" != "$head_host" ]]; then
+      selected_hosts+=("$host")
+    fi
+  done
+fi
+
+if [[ "$comparison_failed" == true ]]; then
+  printf 'warning: derivation comparison failed; selecting every Linux host\n' >&2
+  selected_hosts=("${all_hosts[@]}")
+fi
+
+emit_selection "$darwin_candidate" "${selected_hosts[@]}"

--- a/.github/scripts/test-select-nix-builds.sh
+++ b/.github/scripts/test-select-nix-builds.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+selector="${CI_SELECTOR:-$(dirname "$0")/select-nix-builds.sh}"
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+mock_nix="$test_root/nix"
+printf '#!%s\n' "$BASH" > "$mock_nix"
+cat >> "$mock_nix" <<'EOF'
+set -euo pipefail
+
+target=""
+for argument in "$@"; do
+  case "$argument" in
+    base#* | head#*)
+      target="$argument"
+      ;;
+  esac
+done
+
+if [[ "${MOCK_MODE:-same}" == fail ]]; then
+  exit 1
+fi
+
+jq --compact-output --null-input \
+  --arg mode "${MOCK_MODE:-same}" \
+  --arg target "$target" '
+    {
+      legion: ["legion"],
+      chad: ["chad"],
+      ghost: ["ghost"],
+      forge: ["forge", "forge-disko", "forge-alert-rules"]
+    }
+    | if ($target | startswith("head#")) and $mode == "forge" then
+        .forge += ["changed"]
+      elif ($target | startswith("head#")) and $mode == "chad" then
+        .chad += ["changed"]
+      else
+        .
+      end
+  '
+EOF
+chmod +x "$mock_nix"
+
+assert_selection() {
+  local name="$1"
+  local changed="$2"
+  local mode="$3"
+  local expected="$4"
+  local changed_file="$test_root/$name.changed"
+
+  printf '%s\n' "$changed" > "$changed_file"
+  actual="$({
+    MOCK_MODE="$mode" NIX_COMMAND="$mock_nix" \
+      bash "$selector" base head "$changed_file"
+  } | jq --compact-output --sort-keys '.')"
+
+  if [[ "$actual" != "$expected" ]]; then
+    printf '%s: expected %s, got %s\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_selection \
+  docs-only \
+  docs/machine-forge.md \
+  fail \
+  '{"darwin":false,"hosts":[]}'
+
+assert_selection \
+  forge-only \
+  modules/nixos/server/forge/tangled.nix \
+  forge \
+  '{"darwin":false,"hosts":["forge"]}'
+
+assert_selection \
+  shared-chad \
+  modules/shared/system.nix \
+  chad \
+  '{"darwin":true,"hosts":["chad"]}'
+
+assert_selection \
+  unchanged-lock \
+  flake.lock \
+  same \
+  '{"darwin":true,"hosts":[]}'
+
+assert_selection \
+  linux-evaluation-failure \
+  modules/nixos/server/forge/tangled.nix \
+  fail \
+  '{"darwin":false,"hosts":["legion","chad","ghost","forge"]}'
+
+assert_selection \
+  workflow-change \
+  .github/workflows/nix.yml \
+  fail \
+  '{"darwin":true,"hosts":["legion","chad","ghost","forge"]}'
+
+printf 'CI build selection tests passed\n'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/nix.yml"
+      - ".github/scripts/**"
       - ".sops.yaml"
       - "flake.nix"
       - "flake.lock"
@@ -13,6 +14,7 @@ on:
       - "modules/**"
       - "overlays/**"
       - "pkgs/**"
+      - "public-keys.nix"
       - "secrets/**"
   # Required workflows must run for every PR; path-filtered workflows remain pending.
   pull_request:
@@ -28,6 +30,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Select affected systems
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      hosts: ${{ steps.selection.outputs.hosts }}
+      darwin: ${{ steps.selection.outputs.darwin }}
+      base_sha: ${{ steps.selection.outputs.base_sha }}
+      head_sha: ${{ steps.selection.outputs.head_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: dc-tec-nixos-config
+          skipPush: true
+
+      - name: Compare system derivations
+        id: selection
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request)
+              base_sha="$PULL_REQUEST_BASE_SHA"
+              ;;
+            merge_group)
+              base_sha="$MERGE_GROUP_BASE_SHA"
+              ;;
+            push)
+              base_sha="$PUSH_BASE_SHA"
+              ;;
+            *)
+              base_sha=""
+              ;;
+          esac
+
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+            selection="$(.github/scripts/select-nix-builds.sh --all)"
+          else
+            changed_files="$(mktemp)"
+            trap 'rm -f -- "$changed_files"' EXIT
+            git diff --name-only "$base_sha" "$HEAD_SHA" > "$changed_files"
+
+            repository="git+file://$GITHUB_WORKSPACE"
+            selection="$(.github/scripts/select-nix-builds.sh \
+              "$repository?rev=$base_sha" \
+              "$repository?rev=$HEAD_SHA" \
+              "$changed_files")"
+          fi
+
+          hosts="$(jq --compact-output '.hosts' <<< "$selection")"
+          darwin="$(jq --raw-output '.darwin' <<< "$selection")"
+
+          printf 'Selected Linux hosts: %s\n' "$hosts"
+          printf 'Darwin comparison required: %s\n' "$darwin"
+          {
+            printf 'hosts=%s\n' "$hosts"
+            printf 'darwin=%s\n' "$darwin"
+            printf 'base_sha=%s\n' "$base_sha"
+            printf 'head_sha=%s\n' "$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
+
   quality:
     name: Nix quality checks
     runs-on: ubuntu-24.04
@@ -47,20 +123,22 @@ jobs:
           skipPush: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
 
       - name: Run repository checks
-        run: nix build .#checks.x86_64-linux.pre-commit-check --print-build-logs
+        run: >-
+          nix build
+          .#checks.x86_64-linux.pre-commit-check
+          .#checks.x86_64-linux.ci-build-selection
+          --print-build-logs
 
   hosts:
     name: Build ${{ matrix.host }}
+    needs: changes
+    if: ${{ needs.changes.outputs.hosts != '[]' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        host:
-          - legion
-          - chad
-          - ghost
-          - forge
+        host: ${{ fromJSON(needs.changes.outputs.hosts) }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -88,12 +166,16 @@ jobs:
 
   darwin:
     name: Build darwin
+    needs: changes
+    if: ${{ needs.changes.outputs.darwin == 'true' }}
     runs-on: macos-26
     timeout-minutes: 40
     steps:
       - name: Checkout
         # GitHub's macOS runner currently rejects the full SHA; track restoration in #85.
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Install Nix
         uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
@@ -105,8 +187,35 @@ jobs:
           authToken: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CACHIX_AUTH_TOKEN || '' }}
           skipPush: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
 
+      - name: Compare nix-darwin derivation
+        id: comparison
+        env:
+          BASE_SHA: ${{ needs.changes.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.changes.outputs.head_sha }}
+        run: |
+          changed=true
+          if [[ -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]]; then
+            repository="git+file://$GITHUB_WORKSPACE"
+            if base_drv="$(nix eval --raw \
+              "$repository?rev=$BASE_SHA#checks.aarch64-darwin.darwin-system.drvPath")" \
+              && head_drv="$(nix eval --raw \
+                "$repository?rev=$HEAD_SHA#checks.aarch64-darwin.darwin-system.drvPath")"; then
+              if [[ "$base_drv" == "$head_drv" ]]; then
+                changed=false
+              fi
+            else
+              echo "Darwin comparison failed; falling back to a full build" >&2
+            fi
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
       - name: Build nix-darwin configuration
+        if: steps.comparison.outputs.changed == 'true'
         run: nix build .#checks.aarch64-darwin.darwin-system --print-build-logs
+
+      - name: Report unchanged nix-darwin configuration
+        if: steps.comparison.outputs.changed == 'false'
+        run: echo "The nix-darwin derivation is unchanged; skipping its build."
 
   # Stable branch-protection target for every platform and matrix entry above.
   gate:
@@ -115,17 +224,26 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
+      - changes
       - quality
       - hosts
       - darwin
     steps:
       - name: Require successful checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
           HOSTS_RESULT: ${{ needs.hosts.result }}
           DARWIN_RESULT: ${{ needs.darwin.result }}
         run: |
-          if [[ "$QUALITY_RESULT" != success || "$HOSTS_RESULT" != success || "$DARWIN_RESULT" != success ]]; then
-            echo "Required checks failed: quality=$QUALITY_RESULT hosts=$HOSTS_RESULT darwin=$DARWIN_RESULT"
+          if [[ "$CHANGES_RESULT" != success || "$QUALITY_RESULT" != success ]]; then
+            echo "Required checks failed: changes=$CHANGES_RESULT quality=$QUALITY_RESULT"
             exit 1
           fi
+
+          for result in "$HOSTS_RESULT" "$DARWIN_RESULT"; do
+            if [[ "$result" != success && "$result" != skipped ]]; then
+              echo "Required system build failed: hosts=$HOSTS_RESULT darwin=$DARWIN_RESULT"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ workstation modules. This separation is explicit in `flake.nix`.
   Grafana on Forge;
 - a signed, read-only native Nix binary cache for managed systems;
 - a selectively replicating public Radicle node with a dedicated host
-  identity; and
+  identity;
+- a hardened Tangled Knot for self-hosted public Git repositories; and
 - repository-local packages for repeatable Forge provisioning and cache
   publication.
 

--- a/docs/machine-forge.md
+++ b/docs/machine-forge.md
@@ -21,7 +21,7 @@ The baseline provides:
 - key-only SSH for the `roelc` administrator account;
 - a locked root account and disabled root SSH login;
 - a default-deny firewall;
-- SSH access only through WireGuard, with forwarding disabled;
+- administrative SSH only through WireGuard, with forwarding disabled;
 - fail2ban, SMART monitoring, SSD trimming and compressed swap; and
 - scheduled Nix garbage collection and store optimisation.
 
@@ -61,6 +61,9 @@ WireGuard is the administration boundary:
 The VPN DNS record must remain DNS-only in Cloudflare because the standard
 proxy does not forward WireGuard. Administrative SSH is available at
 `roelc@10.77.0.1`; the provider KVM is the break-glass path.
+The public SSH listener also serves Tangled Git traffic, but `AllowUsers`
+restricts `roelc` to the WireGuard workstation address and permits only the
+Knot's dynamic `git` account from other networks.
 
 Inspect WireGuard and derive the server's public key with:
 
@@ -82,11 +85,14 @@ be reconstructed from this repository:
 - the WireGuard private key;
 - the Nix cache signing key;
 - the Radicle node identity key; and
-- the SSH host keys.
+- the SSH host keys; and
+- the Tangled Knot database and hosted Git repositories.
 
-Nix store paths, cache contents, logs, metrics and public repositories are not
-included. New stateful services must add their authoritative state explicitly.
-The backend's 1000-object limit is monitored and constrains future expansion.
+Nix store paths, cache contents, logs, metrics and reconstructible Radicle
+replicas are not included. The Knot is authoritative for repositories assigned
+to it, so its state is included even though those repositories are public. New
+stateful services must add their authoritative state explicitly. The backend's
+1000-object limit is monitored and constrains future expansion.
 
 SecretSpec resolves the Restic password from the operator's Apple Keychain and
 provisions it over WireGuard. It is not a runtime dependency of Forge:
@@ -109,6 +115,11 @@ The schedule and retention policy are:
 - weekly maintenance on Sunday at 05:30;
 - 14 daily, 8 weekly and 6 monthly snapshots; and
 - weekly prune followed by a full repository data check.
+
+The state job stops the Knot before Restic reads its SQLite database and bare
+repositories, then restarts it in the cleanup hook even when the backup fails.
+This creates one consistent snapshot at the cost of pausing Git hosting for the
+duration of the nightly state backup.
 
 Inspect or run the jobs with:
 
@@ -151,7 +162,9 @@ The alert rules cover:
 - inode exhaustion and OOM kills;
 - backup and inventory freshness;
 - the Dedibackup object limit; and
-- public cache health and signing-key presence.
+- public cache health and signing-key presence;
+- Radicle replication health and declared repository policy; and
+- Tangled Knot state, listeners, public endpoint and owner identity.
 
 CPU saturation is intentionally not an alert because Nix builds are expected
 to use the host fully. Warning and critical capacity thresholds do not overlap.
@@ -310,6 +323,71 @@ To roll back the service, stop the node and remove the module from the Forge
 composition. Preserve the identity key until the old Node ID and address have
 been retired deliberately.
 
+## Tangled Knot
+
+Forge runs a single-operator Tangled Knot at `knot.decort.tech`. The Knot hosts
+Git data while the public `tangled.org` AppView and the operator's existing AT
+Protocol identity provide discovery and collaboration records. Forge does not
+run an AppView, PDS, PLC directory, search service or Spindle in this slice.
+
+The deployment pins Tangled `v1.16.1-alpha` and uses its upstream NixOS module.
+Its network boundaries are:
+
+| Surface | Exposure | Purpose |
+| --- | --- | --- |
+| HTTPS `443` | Public through Nginx and ACME | Knot HTTP, XRPC and event endpoints |
+| SSH `22` as `git` | Public | Git clone, fetch and push |
+| SSH `22` as `roelc` | WireGuard source `10.77.0.2` only | Host administration |
+| HTTP `127.0.0.1:5555` | Loopback | Nginx upstream |
+| HTTP `127.0.0.1:5444` | Loopback | Knot internal API and SSH key lookup |
+
+The Cloudflare record must remain DNS-only. TLS terminates on Forge and Git SSH
+does not traverse the Cloudflare proxy. Knot ownership is declared as:
+
+```text
+did:plc:wrl7x5yocird6ep6472fkm3a
+```
+
+Secure Mode is enabled. Git subprocesses are confined to their repository with
+Landlock and run under owner-specific virtual UIDs. Forge's kernel is newer
+than the upstream Linux 5.19 requirement for push-safe Landlock isolation. The
+service receives only the setuid, setgid and chown capabilities required by
+that mode and has explicit memory, task and systemd hardening limits. The
+upstream release emits debug-level logs unconditionally; a per-service burst
+limit prevents automated public scans from overwhelming journald.
+
+Authoritative state lives under `/var/lib/tangled-knot`:
+
+- `knotserver.db` contains the Knot database and access model;
+- `repos/` contains the hosted bare repositories; and
+- the system OpenSSH host key provides continuity for Git clients.
+
+This state is backed up consistently by the daily Forge state job. Restore the
+directory and SSH host keys before announcing a replacement Knot. The Knot has
+no additional bootstrap secret in this version; its owner and public service
+configuration are declarative.
+
+After the service passes its local and public checks, register
+`knot.decort.tech` from the Knot settings page on `tangled.org`. Registration
+publishes the Knot record through the operator's PDS and verifies the public
+owner endpoint. Do not register an incomplete or temporary deployment.
+
+Inspect the service with:
+
+```console
+ssh roelc@10.77.0.1 systemctl status knot.service
+ssh roelc@10.77.0.1 sudo journalctl -u knot.service
+curl -fsS https://knot.decort.tech/
+curl -fsS https://knot.decort.tech/xrpc/sh.tangled.owner | jq
+ssh -T git@knot.decort.tech
+```
+
+Monitoring checks both loopback listeners, the public TLS endpoint, the owner
+DID and the on-disk database. The dashboard also reports repository count and
+state size. To roll back, remove the Knot module and Nginx virtual host, then
+switch the Forge configuration. Preserve `/var/lib/tangled-knot` and the SSH
+host keys until the Knot registration has been retired or moved deliberately.
+
 ## Build and Deployment
 
 Evaluate the Forge system and Disko derivations from any supported client:
@@ -349,9 +427,8 @@ nix run .#nixos-anywhere -- \
 
 Stateful applications are added as independent, reversible slices:
 
-1. a Tangled knot;
-2. OpenBao with identity integration; and
-3. an optional private Attic evaluation, separate from the native cache.
+1. OpenBao with identity integration; and
+2. an optional private Attic evaluation, separate from the native cache.
 
 Each service must define its network exposure, state ownership, backup and
 restore procedure, monitoring, acceptance checks and rollback path.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "actor-typeahead-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762835797,
+        "narHash": "sha256-heizoWUKDdar6ymfZTnj3ytcEv/L4d4fzSmtr0HlXsQ=",
+        "ref": "refs/heads/main",
+        "rev": "677fe7f743050a4e7f09d4a6f87bbf1325a06f6b",
+        "revCount": 6,
+        "type": "git",
+        "url": "https://tangled.org/@jakelazaroff.com/actor-typeahead"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://tangled.org/@jakelazaroff.com/actor-typeahead"
+      }
+    },
     "base16-schemes": {
       "flake": false,
       "locked": {
@@ -76,6 +92,49 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "tangled",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1780397302,
+        "narHash": "sha256-SQmrkj17xBdvc8lVMbsY7pIJCjKftgNh42R1keP3dLQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f6670530f53e69cc284f7aef818eb0f08fe81905",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fetch-tangled": {
+      "inputs": {
+        "nixpkgs": [
+          "tangled",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779479671,
+        "narHash": "sha256-8PR9nZnK0Fn4gDOikz+3sLdsEJYnKC3gaunBs4N+V9Q=",
+        "ref": "refs/heads/main",
+        "rev": "2e3744d31b990248f277d16a11ef81753b366f0f",
+        "revCount": 22,
+        "type": "git",
+        "url": "https://tangled.org/isabelroses.com/fetch-tangled"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://tangled.org/isabelroses.com/fetch-tangled"
+      }
+    },
     "firefox-addons": {
       "inputs": {
         "nixpkgs": [
@@ -103,6 +162,22 @@
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
@@ -114,7 +189,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -130,7 +205,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -225,6 +300,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gomod2nix": {
       "inputs": {
         "flake-utils": [
@@ -248,6 +341,40 @@
         "owner": "nix-community",
         "repo": "gomod2nix",
         "type": "github"
+      }
+    },
+    "gomod2nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "tangled",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763982521,
+        "narHash": "sha256-ur4QIAHwgFc0vXiaxn5No/FuZicxBr2p0gmT54xZkUQ=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "02e63a239d6eabd595db56852535992c898eba72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "hls-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-mmxgaQRXXWzRG6/OlOn5efV+NmzhvmXTQaFbODqh0b8=",
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/hls.js@1.5.13/dist/hls.min.js"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/hls.js@1.5.13/dist/hls.min.js"
       }
     },
     "home-manager": {
@@ -291,6 +418,43 @@
         "type": "github"
       }
     },
+    "htmx-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-nm6avZuEBg67SSyyZUhjpXVNstHHgUxrtBHqJgowU08=",
+        "type": "file",
+        "url": "https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"
+      }
+    },
+    "htmx-ws-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-2fg6KyEJoO24q0fQqbz9RMaYNPQrMwpZh29tkSqdqGY=",
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/htmx-ext-ws@2.0.2"
+      }
+    },
+    "ibm-plex-mono-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731402384,
+        "narHash": "sha256-OwUmrPfEehLDz0fl2ChYLK8FQM2p0G1+EMrGsYEq+6g=",
+        "type": "tarball",
+        "url": "https://github.com/IBM/plex/releases/download/@ibm%2Fplex-mono@1.1.0/ibm-plex-mono.zip"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/IBM/plex/releases/download/@ibm%2Fplex-mono@1.1.0/ibm-plex-mono.zip"
+      }
+    },
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager_2",
@@ -307,6 +471,94 @@
       "original": {
         "owner": "nix-community",
         "repo": "impermanence",
+        "type": "github"
+      }
+    },
+    "indigo": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753693716,
+        "narHash": "sha256-DMIKnCJRODQXEHUxA+7mLzRALmnZhkkbHlFT2rCQYrE=",
+        "owner": "oppiliappan",
+        "repo": "indigo",
+        "rev": "5f170569da9360f57add450a278d73538092d8ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oppiliappan",
+        "repo": "indigo",
+        "type": "github"
+      }
+    },
+    "inter-fonts-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731687360,
+        "narHash": "sha256-5vdKKvHAeZi6igrfpbOdhZlDX2/5+UvzlnCQV6DdqoQ=",
+        "type": "tarball",
+        "url": "https://github.com/rsms/inter/releases/download/v4.1/Inter-4.1.zip"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/rsms/inter/releases/download/v4.1/Inter-4.1.zip"
+      }
+    },
+    "lucide-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754044466,
+        "narHash": "sha256-+exBR2OToB1iv7ZQI2S4B0lXA/QRvC9n6U99UxGpJGs=",
+        "type": "tarball",
+        "url": "https://github.com/lucide-icons/lucide/releases/download/0.536.0/lucide-icons-0.536.0.zip"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/lucide-icons/lucide/releases/download/0.536.0/lucide-icons-0.536.0.zip"
+      }
+    },
+    "mathjax-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-eqg25bKfiDzynRMR2RfeWNfo0EefHF/eRRFafl9RnNI=",
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/mathjax@4.1.2/tex-svg.js"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/mathjax@4.1.2/tex-svg.js"
+      }
+    },
+    "mermaid-src": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-/YOdECG2V5c3kJ1QfGvhziTT6K/Dx/4mOk2mr3Fs/do=",
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js"
+      }
+    },
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "tangled",
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1779970379,
+        "narHash": "sha256-ZHsxoYXXnfJtMVh1/yY+1Eh9hHcPBhE28Qvinauh+BQ=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "0d49083ba2d7419b22908ac392777c16df9a032e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
         "type": "github"
       }
     },
@@ -442,7 +694,7 @@
     },
     "nixos-wsl": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -711,7 +963,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
@@ -730,7 +982,7 @@
     },
     "pre-commit-hooks_2": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -755,6 +1007,7 @@
         "darwin": "darwin",
         "disko": "disko",
         "firefox-addons": "firefox-addons",
+        "flake-compat": "flake-compat",
         "home-manager": "home-manager",
         "impermanence": "impermanence",
         "ndg": "ndg",
@@ -768,7 +1021,25 @@
         "nixvim": "nixvim",
         "nur": "nur",
         "pre-commit-hooks": "pre-commit-hooks_2",
-        "sops-nix": "sops-nix"
+        "sops-nix": "sops-nix",
+        "tangled": "tangled"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780337665,
+        "narHash": "sha256-RS3F+/6dtBIwd5+47GVen3jAk62/KumFZ4q3RVYafDk=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "55af1774e9e840d3b28d12fcfaa72d2e2caa8ac9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "sops-nix": {
@@ -789,6 +1060,35 @@
         "owner": "Mic92",
         "repo": "sops-nix",
         "type": "github"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778940603,
+        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
+        "ref": "refs/heads/main",
+        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
+        "revCount": 1265,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    },
+    "sqlite-lib-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1706631843,
+        "narHash": "sha256-bJoMjirsBjm2Qk9KPiy3yV3+8b/POlYe76/FQbciHro=",
+        "type": "tarball",
+        "url": "https://sqlite.org/2024/sqlite-amalgamation-3450100.zip"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://sqlite.org/2024/sqlite-amalgamation-3450100.zip"
       }
     },
     "systems": {
@@ -820,6 +1120,60 @@
         "ref": "future-26.11",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tangled": {
+      "inputs": {
+        "actor-typeahead-src": "actor-typeahead-src",
+        "fenix": "fenix",
+        "fetch-tangled": "fetch-tangled",
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "gomod2nix": "gomod2nix_2",
+        "hls-src": "hls-src",
+        "htmx-src": "htmx-src",
+        "htmx-ws-src": "htmx-ws-src",
+        "ibm-plex-mono-src": "ibm-plex-mono-src",
+        "indigo": "indigo",
+        "inter-fonts-src": "inter-fonts-src",
+        "lucide-src": "lucide-src",
+        "mathjax-src": "mathjax-src",
+        "mermaid-src": "mermaid-src",
+        "microvm": "microvm",
+        "nixpkgs": [
+          "nixpkgs-stable"
+        ],
+        "sqlite-lib-src": "sqlite-lib-src"
+      },
+      "locked": {
+        "lastModified": 1784281897,
+        "narHash": "sha256-H1c7viFj0F5pusxPx8hayPyIYHeNesS6C/WFIHUUpZU=",
+        "ref": "refs/tags/v1.16.1-alpha",
+        "rev": "1d379a324497da39a27e49453c72615607a9b199",
+        "revCount": 2931,
+        "type": "git",
+        "url": "https://tangled.org/tangled.org/core"
+      },
+      "original": {
+        "ref": "refs/tags/v1.16.1-alpha",
+        "type": "git",
+        "url": "https://tangled.org/tangled.org/core"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     niks-cli.url = "github:dc-tec/niks-cli";
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
+    tangled = {
+      url = "git+https://tangled.org/tangled.org/core?ref=refs/tags/v1.16.1-alpha";
+      inputs.flake-compat.follows = "flake-compat";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
+    };
 
     # Others
     nur.url = "github:nix-community/NUR";
@@ -234,6 +243,22 @@
               nixfmt.enable = true;
             };
           };
+          ci-build-selection =
+            let
+              pkgs = mkPkgs system;
+            in
+            pkgs.runCommand "ci-build-selection"
+              {
+                nativeBuildInputs = [
+                  pkgs.bash
+                  pkgs.jq
+                ];
+              }
+              ''
+                CI_SELECTOR=${./.github/scripts/select-nix-builds.sh} \
+                  bash ${./.github/scripts/test-select-nix-builds.sh}
+                touch "$out"
+              '';
         }
         // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
           forge-alert-rules =

--- a/machines/forge/default.nix
+++ b/machines/forge/default.nix
@@ -17,7 +17,10 @@
     useDHCP = false;
     interfaces.enp1s0f0.useDHCP = true;
   };
-  services.openssh.settings.AllowUsers = [ "roelc" ];
+  services.openssh.settings.AllowUsers = [
+    "git"
+    "roelc@10.77.0.2"
+  ];
 
   users.users.roelc = {
     isNormalUser = true;

--- a/modules/nixos/server/forge/backup.nix
+++ b/modules/nixos/server/forge/backup.nix
@@ -28,6 +28,8 @@ in
 {
   services.restic.backups = {
     forge-state = dedibackup // {
+      paths = [ "/var/lib/tangled-knot" ];
+
       dynamicFilesFrom = ''
         printf '%s\n' /var/lib/wireguard/forge.key
         if [ -f /var/lib/forge-secrets/nix-cache-private-key ]; then
@@ -41,6 +43,28 @@ in
           -type f \
           -name 'ssh_host_*' \
           -print
+      '';
+
+      # The Knot combines mutable bare repositories with a WAL-mode SQLite
+      # database. Quiescing it keeps both parts in one consistent Restic
+      # snapshot. The post-stop hook runs even when Restic fails.
+      backupPrepareCommand = ''
+        #!${pkgs.runtimeShell}
+        set -euo pipefail
+        marker="$RUNTIME_DIRECTORY/tangled-knot-was-active"
+        if ${lib.getExe' pkgs.systemd "systemctl"} is-active --quiet knot.service; then
+          ${lib.getExe' pkgs.coreutils "touch"} "$marker"
+          ${lib.getExe' pkgs.systemd "systemctl"} stop knot.service
+        fi
+      '';
+      backupCleanupCommand = ''
+        #!${pkgs.runtimeShell}
+        set -euo pipefail
+        marker="$RUNTIME_DIRECTORY/tangled-knot-was-active"
+        if [ -e "$marker" ]; then
+          ${lib.getExe' pkgs.coreutils "rm"} -f -- "$marker"
+          ${lib.getExe' pkgs.systemd "systemctl"} start knot.service
+        fi
       '';
 
       initialize = false;

--- a/modules/nixos/server/forge/default.nix
+++ b/modules/nixos/server/forge/default.nix
@@ -5,5 +5,6 @@ _: {
     ./cache.nix
     ./monitoring.nix
     ./radicle.nix
+    ./tangled.nix
   ];
 }

--- a/modules/nixos/server/forge/grafana-dashboards/forge-overview.json
+++ b/modules/nixos/server/forge/grafana-dashboards/forge-overview.json
@@ -913,6 +913,200 @@
       ],
       "title": "Radicle health",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Unavailable"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Healthy"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "min({__name__=~\"forge_tangled_knot_(database_present|service_active|http_listener_ready|internal_listener_ready|public_http_ready|owner_matches)\"})",
+          "instant": true,
+          "legendFormat": "Health",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Tangled Knot health",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "forge_tangled_knot_repositories",
+          "instant": true,
+          "legendFormat": "Repositories",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Tangled repositories",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "forge_tangled_knot_state_bytes",
+          "instant": true,
+          "legendFormat": "State",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Tangled state",
+      "type": "stat"
     }
   ],
   "refresh": "30s",
@@ -931,5 +1125,5 @@
   "timezone": "browser",
   "title": "Forge Overview",
   "uid": "forge-overview",
-  "version": 2
+  "version": 3
 }

--- a/modules/nixos/server/forge/prometheus-rules.test.yml
+++ b/modules/nixos/server/forge/prometheus-rules.test.yml
@@ -397,3 +397,74 @@ tests:
       - eval_time: 30m
         alertname: ForgeBackupObjectLimitWarning
         exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'forge_tangled_knot_database_present{instance="forge",job="node"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeTangledKnotDatabaseMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              category: tangled
+              instance: forge
+              job: node
+            exp_annotations:
+              summary: "Forge Tangled Knot database is missing"
+              description: "The Knot SQLite database has not been created or is no longer present."
+
+  - interval: 1m
+    input_series:
+      - series: 'forge_tangled_knot_database_present{instance="forge",job="node"}'
+        values: "1x15"
+      - series: 'forge_tangled_knot_service_active{instance="forge",job="node"}'
+        values: "1x15"
+      - series: 'forge_tangled_knot_http_listener_ready{instance="forge",job="node"}'
+        values: "1x15"
+      - series: 'forge_tangled_knot_internal_listener_ready{instance="forge",job="node"}'
+        values: "1x15"
+      - series: 'forge_tangled_knot_public_http_ready{instance="forge",job="node"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeTangledKnotUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              category: tangled
+              instance: forge
+              job: node
+            exp_annotations:
+              summary: "Forge Tangled Knot is unavailable"
+              description: "The Knot has state, but its service, local listeners, or public TLS endpoint is unavailable."
+
+  - interval: 1m
+    input_series:
+      - series: 'forge_tangled_knot_owner_matches{instance="forge",job="node"}'
+        values: "0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeTangledKnotOwnerMismatch
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              category: tangled
+              instance: forge
+              job: node
+            exp_annotations:
+              summary: "Forge Tangled Knot owner does not match"
+              description: "The public Knot owner endpoint does not return the configured operator DID."
+
+  - interval: 1m
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ForgeTangledKnotMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              category: tangled
+            exp_annotations:
+              summary: "Forge Tangled Knot metrics are stale"
+              description: "No successful Tangled Knot metrics scan has been recorded within the last 15 minutes."

--- a/modules/nixos/server/forge/prometheus-rules.yml
+++ b/modules/nixos/server/forge/prometheus-rules.yml
@@ -13,7 +13,7 @@ groups:
 
       - alert: ForgeServiceFailed
         expr: >-
-          node_systemd_unit_state{instance="forge",state="failed",name=~"(grafana|prometheus|prometheus-node-exporter|prometheus-smartctl-exporter|alertmanager|nginx|radicle-node|restic-backups-forge-state|restic-backups-forge-maintenance|forge-backup-.*-metrics|forge-cache-.*|forge-radicle-.*)\\.service"} == 1
+          node_systemd_unit_state{instance="forge",state="failed",name=~"(grafana|prometheus|prometheus-node-exporter|prometheus-smartctl-exporter|alertmanager|nginx|knot|radicle-node|restic-backups-forge-state|restic-backups-forge-maintenance|forge-backup-.*-metrics|forge-cache-.*|forge-radicle-.*|forge-tangled-knot-.*)\\.service"} == 1
         for: 5m
         labels:
           severity: critical
@@ -198,6 +198,57 @@ groups:
         annotations:
           summary: "Forge Radicle metrics are stale"
           description: "No successful Radicle metrics scan has been recorded within the last 15 minutes."
+
+  - name: forge-tangled-knot
+    rules:
+      - alert: ForgeTangledKnotDatabaseMissing
+        expr: forge_tangled_knot_database_present == 0
+        for: 10m
+        labels:
+          severity: critical
+          category: tangled
+        annotations:
+          summary: "Forge Tangled Knot database is missing"
+          description: "The Knot SQLite database has not been created or is no longer present."
+
+      - alert: ForgeTangledKnotUnavailable
+        expr: >-
+          (forge_tangled_knot_database_present == 1)
+          and
+          ((forge_tangled_knot_service_active == 0)
+          or (forge_tangled_knot_http_listener_ready == 0)
+          or (forge_tangled_knot_internal_listener_ready == 0)
+          or (forge_tangled_knot_public_http_ready == 0))
+        for: 10m
+        labels:
+          severity: warning
+          category: tangled
+        annotations:
+          summary: "Forge Tangled Knot is unavailable"
+          description: "The Knot has state, but its service, local listeners, or public TLS endpoint is unavailable."
+
+      - alert: ForgeTangledKnotOwnerMismatch
+        expr: forge_tangled_knot_owner_matches == 0
+        for: 10m
+        labels:
+          severity: critical
+          category: tangled
+        annotations:
+          summary: "Forge Tangled Knot owner does not match"
+          description: "The public Knot owner endpoint does not return the configured operator DID."
+
+      - alert: ForgeTangledKnotMetricsStale
+        expr: >-
+          (time() - forge_tangled_knot_last_scan_timestamp_seconds > 900)
+          or
+          absent(forge_tangled_knot_last_scan_timestamp_seconds)
+        for: 10m
+        labels:
+          severity: warning
+          category: tangled
+        annotations:
+          summary: "Forge Tangled Knot metrics are stale"
+          description: "No successful Tangled Knot metrics scan has been recorded within the last 15 minutes."
 
   - name: forge-backup
     rules:

--- a/modules/nixos/server/forge/tangled.nix
+++ b/modules/nixos/server/forge/tangled.nix
@@ -1,0 +1,262 @@
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  hostname = "knot.decort.tech";
+  ownerDid = "did:plc:wrl7x5yocird6ep6472fkm3a";
+  stateDir = "/var/lib/tangled-knot";
+  repositoryDir = "${stateDir}/repos";
+  databaseFile = "${stateDir}/knotserver.db";
+  metricDirectory = "/var/lib/prometheus-node-exporter-text-files";
+  publicListenAddress = "127.0.0.1:5555";
+  internalListenAddress = "127.0.0.1:5444";
+
+  knotMetrics = pkgs.writeShellApplication {
+    name = "forge-tangled-knot-metrics";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.curl
+      pkgs.findutils
+      pkgs.gnugrep
+      pkgs.iproute2
+      pkgs.jq
+      pkgs.systemd
+    ];
+    text = ''
+      target="${metricDirectory}/forge_tangled_knot.prom"
+      temporary="$target.$$"
+      trap 'rm -f -- "$temporary"' EXIT
+
+      if [[ -s "${databaseFile}" ]]; then
+        database_present=1
+      else
+        database_present=0
+      fi
+
+      if systemctl is-active --quiet knot.service; then
+        service_active=1
+      else
+        service_active=0
+      fi
+
+      if ss --no-header --listening --tcp --numeric \
+        'sport = :5555' | grep --quiet '127.0.0.1:5555'; then
+        http_listener_ready=1
+      else
+        http_listener_ready=0
+      fi
+
+      if ss --no-header --listening --tcp --numeric \
+        'sport = :5444' | grep --quiet '127.0.0.1:5444'; then
+        internal_listener_ready=1
+      else
+        internal_listener_ready=0
+      fi
+
+      if curl --fail --silent --show-error --max-time 10 \
+        "https://${hostname}/" >/dev/null; then
+        public_http_ready=1
+      else
+        public_http_ready=0
+      fi
+
+      owner_response="$(${lib.getExe pkgs.curl} \
+        --fail \
+        --silent \
+        --show-error \
+        --max-time 10 \
+        "https://${hostname}/xrpc/sh.tangled.owner" 2>/dev/null || true)"
+      if [[ "$(${lib.getExe pkgs.jq} -r '.owner // empty' \
+        <<< "$owner_response" 2>/dev/null || true)" == "${ownerDid}" ]]; then
+        owner_matches=1
+      else
+        owner_matches=0
+      fi
+
+      repository_count=0
+      while IFS= read -r -d $'\0' repository; do
+        if [[ -f "$repository/HEAD" ]]; then
+          repository_count=$((repository_count + 1))
+        fi
+      done < <(
+        find "${repositoryDir}" \
+          -mindepth 1 -maxdepth 1 -type d -name 'did:*' -print0 \
+          2>/dev/null || true
+      )
+      state_bytes="$(du --summarize --bytes "${stateDir}" 2>/dev/null \
+        | cut --fields=1 || printf 0)"
+
+      printf '%s\n' \
+        '# HELP forge_tangled_knot_database_present Whether the Knot SQLite database exists.' \
+        '# TYPE forge_tangled_knot_database_present gauge' \
+        "forge_tangled_knot_database_present $database_present" \
+        '# HELP forge_tangled_knot_service_active Whether the Knot systemd service is active.' \
+        '# TYPE forge_tangled_knot_service_active gauge' \
+        "forge_tangled_knot_service_active $service_active" \
+        '# HELP forge_tangled_knot_http_listener_ready Whether the loopback HTTP listener is ready.' \
+        '# TYPE forge_tangled_knot_http_listener_ready gauge' \
+        "forge_tangled_knot_http_listener_ready $http_listener_ready" \
+        '# HELP forge_tangled_knot_internal_listener_ready Whether the loopback administrative listener is ready.' \
+        '# TYPE forge_tangled_knot_internal_listener_ready gauge' \
+        "forge_tangled_knot_internal_listener_ready $internal_listener_ready" \
+        '# HELP forge_tangled_knot_public_http_ready Whether the public TLS endpoint is reachable.' \
+        '# TYPE forge_tangled_knot_public_http_ready gauge' \
+        "forge_tangled_knot_public_http_ready $public_http_ready" \
+        '# HELP forge_tangled_knot_owner_matches Whether the public owner endpoint returns the declared DID.' \
+        '# TYPE forge_tangled_knot_owner_matches gauge' \
+        "forge_tangled_knot_owner_matches $owner_matches" \
+        '# HELP forge_tangled_knot_repositories Number of repository directories on this Knot.' \
+        '# TYPE forge_tangled_knot_repositories gauge' \
+        "forge_tangled_knot_repositories $repository_count" \
+        '# HELP forge_tangled_knot_state_bytes Logical bytes occupied by Knot state.' \
+        '# TYPE forge_tangled_knot_state_bytes gauge' \
+        "forge_tangled_knot_state_bytes $state_bytes" \
+        '# HELP forge_tangled_knot_last_scan_timestamp_seconds Unix timestamp of the last Knot metrics scan.' \
+        '# TYPE forge_tangled_knot_last_scan_timestamp_seconds gauge' \
+        "forge_tangled_knot_last_scan_timestamp_seconds $(date +%s)" \
+        > "$temporary"
+
+      chmod 0644 "$temporary"
+      mv --force -- "$temporary" "$target"
+    '';
+  };
+in
+{
+  imports = [ inputs.tangled.nixosModules.knot ];
+
+  services = {
+    tangled.knot = {
+      enable = true;
+      appviewEndpoint = "https://tangled.org";
+      openFirewall = true;
+      inherit stateDir;
+      repo.scanPath = repositoryDir;
+      git = {
+        # The upstream module emits this value as a systemd Environment=
+        # assignment, so keep it free of whitespace.
+        userName = "deCort.tech";
+        userEmail = "noreply@decort.tech";
+      };
+      motd = "Tangled Knot operated by deCort.tech.\n";
+      server = {
+        hostname = hostname;
+        owner = ownerDid;
+        listenAddr = publicListenAddress;
+        internalListenAddr = internalListenAddress;
+        dev = false;
+        logDids = false;
+        secureMode = true;
+      };
+    };
+
+    nginx = {
+      recommendedProxySettings = true;
+      virtualHosts.${hostname} = {
+        enableACME = true;
+        forceSSL = true;
+        locations."/" = {
+          proxyPass = "http://${publicListenAddress}";
+          proxyWebsockets = true;
+          extraConfig = ''
+            client_max_body_size 100m;
+            proxy_read_timeout 300s;
+            add_header X-Content-Type-Options nosniff always;
+          '';
+        };
+      };
+    };
+  };
+
+  systemd = {
+    services = {
+      knot = {
+        # The upstream migration step may leave SQLite sidecar files owned by
+        # root on the first start. Normalize the complete database set before
+        # the service drops privileges to the git user.
+        preStart = lib.mkAfter ''
+          for sqliteFile in \
+            "${databaseFile}" \
+            "${databaseFile}-shm" \
+            "${databaseFile}-wal"; do
+            if [[ -e "$sqliteFile" ]]; then
+              ${pkgs.coreutils}/bin/chown git:git "$sqliteFile"
+            fi
+          done
+        '';
+        serviceConfig = {
+          RestartSec = "5s";
+          LogRateLimitIntervalSec = "30s";
+          LogRateLimitBurst = 500;
+          MemoryHigh = "2G";
+          MemoryMax = "4G";
+          TasksMax = 512;
+          LimitNOFILE = 65536;
+          UMask = "0027";
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          ReadWritePaths = [ stateDir ];
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+        };
+      };
+
+      forge-tangled-knot-metrics = {
+        description = "Collect Forge Tangled Knot metrics";
+        wants = [ "network-online.target" ];
+        after = [
+          "network-online.target"
+          "knot.service"
+          "nginx.service"
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = lib.getExe knotMetrics;
+          User = "root";
+          Group = "root";
+          UMask = "0022";
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "strict";
+          ReadOnlyPaths = [ stateDir ];
+          ReadWritePaths = [ metricDirectory ];
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+            "AF_UNIX"
+          ];
+        };
+      };
+    };
+
+    timers.forge-tangled-knot-metrics = {
+      description = "Schedule Forge Tangled Knot metrics collection";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "3m";
+        OnUnitActiveSec = "5m";
+        Unit = "forge-tangled-knot-metrics.service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- run a hardened Tangled Knot on Forge with public HTTPS and Git SSH access
- include authoritative Knot state in Restic backups and add Prometheus/Grafana coverage
- compare base and head derivations so CI builds only affected NixOS and nix-darwin configurations
- document the service boundary, recovery model, registration procedure, and operational tradeoffs

## Motivation

Forge needs a sovereign public Git hosting service alongside Radicle. The existing CI matrix also rebuilt every machine for isolated host changes, which spent runner time without adding coverage.

The selector uses path classification only to identify relevant platforms, then compares derivation fingerprints to determine the exact machines to build. Evaluation failures fall back to the complete Linux matrix.

## Validation

- `actionlint`, `deadnix`, and `nixfmt`
- selector unit tests, including evaluation-failure fallback
- real base/head selector comparison: Forge selected; other Linux hosts unchanged
- native nix-darwin derivation comparison: unchanged
- `nix flake archive`
- nix-darwin configuration build
- Forge alert-rule tests with `promtool`
- final Forge closure built and test-activated
- live Knot TLS, XRPC owner DID, listener, systemd, timer, monitoring, and backup integration checks

## Operational notes

- This PR changes the selector itself, so its first CI run intentionally validates the complete Linux matrix.
- The nightly state backup pauses the Knot while Restic snapshots its SQLite database and repositories.
- The deployed Forge generation remains a non-persistent test activation until this PR is merged and the accepted configuration is switched persistently.
