### PR TITLE
fix(nixvim): preserve pinned nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -853,6 +853,22 @@
     },
     "nixpkgs_6": {
       "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
         "lastModified": 1784555310,
         "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
@@ -867,7 +883,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1782918843,
         "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
@@ -883,7 +899,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1785090369,
         "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
@@ -902,9 +918,7 @@
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_6",
         "nixvim": "nixvim_2",
         "pre-commit-hooks": "pre-commit-hooks"
       },
@@ -925,7 +939,7 @@
     "nixvim_2": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "systems": "systems_2"
       },
       "locked": {
@@ -945,7 +959,7 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1785186128,
@@ -964,7 +978,7 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1784288435,

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,6 @@
     # Custom Flakes
     nixvim = {
       url = "github:dc-tec/nixvim";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
     niks-cli.url = "github:dc-tec/niks-cli";
     flake-compat = {


### PR DESCRIPTION
## Summary

- let the Nixvim flake retain its own tested Nixpkgs input
- refresh the lock graph so the configured Nixvim package uses CodeDiff 2.53.1

## Root cause

The parent flake forced Nixvim to follow its top-level Nixpkgs input. That replaced the package set validated by the Nixvim flake and downgraded CodeDiff to 2.49.2, which lacks the required synchronized scrolling behavior.

## Impact

The installed Nixvim package now matches the package set used by nix run . in the Nixvim repository. This adds a dedicated Nixpkgs node to the lock graph.

## Validation

- nix develop --command pre-commit run --all-files
- nix build .#checks.aarch64-darwin.darwin-system --no-link --print-build-logs
- verified the built and activated CodeDiff package is 2.53.1
- opened a headless CodeDiff session successfully
- completed a live Darwin activation